### PR TITLE
replace `stmt` by `typed` in nimble file

### DIFF
--- a/nimcl.nimble
+++ b/nimcl.nimble
@@ -8,7 +8,7 @@ skipFiles     = @["points.json"]
 requires "nim >= 0.13.0", "opencl >= 1.0"
 
 
-template dependsOn*(task: untyped): stmt =
+template dependsOn*(task: untyped): typed =
   exec "nimble " & astToStr(task)
 
 proc addDefaults() =


### PR DESCRIPTION
All deprecated symbols in `system.nim` were removed in Nim commit
https://github.com/nim-lang/Nim/commit/c7298561c199255facc562402700322360408179
which is why nimcl cannot be installed anymore on current devel.

I'm not sure how far back `typed` was implemented and whether `0.13.0` is supported by this change tbh.